### PR TITLE
OFX Mapping fix to enable support for Money Pro

### DIFF
--- a/extrato-nubank.js
+++ b/extrato-nubank.js
@@ -14,30 +14,49 @@ OLDFILEUID:NONE
 NEWFILEUID:NONE
 
 <OFX>
-<BANKMSGSRSV1>
-<STMTTRNRS>
-<STMTRS>
-<BANKTRANLIST>`;
-  }
-
-  function endOfx() {
-    return `
-</BANKTRANLIST>
-</STMTRS>
-</STMTTRNRS>
-</BANKMSGSRSV1>
+  <SIGNONMSGSRSV1>
+      <SONRS>
+          <STATUS>
+              <CODE>0
+              <SEVERITY>INFO
+          </STATUS>
+          <DTSERVER>20160711
+          <LANGUAGE>ENG
+          <FI>
+              <ORG>NUBANK
+              <FID>NUBANK
+          </FI>
+      </SONRS>
+  </SIGNONMSGSRSV1>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <STMTRS>
+        <BANKACCTFROM>
+            <BANKID>NUBANK</BANKID>
+            <ACCTID>0</ACCTID>
+            <ACCTTYPE>LINEOFCREDIT</ACCTTYPE>
+        </BANKACCTFROM>
+        <BANKTRANLIST>`;
+          }
+        
+          function endOfx() {
+            return `
+        </BANKTRANLIST>
+      </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
 </OFX>`;
     
   }
 
   function bankStatement(date, amount, description) {
     return `
-<STMTTRN>
-<TRNTYPE>OTHER</TRNTYPE>
-<DTPOSTED>${date}</DTPOSTED>
-<TRNAMT>${amount}</TRNAMT>
-<MEMO>${description}</MEMO>
-</STMTTRN>`;
+      <STMTTRN>
+      <TRNTYPE>OTHER</TRNTYPE>
+      <DTPOSTED>${date}</DTPOSTED>
+      <TRNAMT>${amount * -1}</TRNAMT>
+      <MEMO>${description}</MEMO>
+      </STMTTRN>`;
   }
 
   function normalizeAmount(text) {

--- a/extrato-nubank.js
+++ b/extrato-nubank.js
@@ -101,7 +101,7 @@ NEWFILEUID:NONE
   }
 
   function generateOfx() {
-    var ofx = startOfx(normalizeDate($(this).find('.period>span')[0].text()), normalizeDate($(this).find('.period>span')[1].text()));
+    var ofx = startOfx(normalizeDate($.find('.period>span')[0].text()), normalizeDate($.find('.period>span')[1].text()));
 
     $('.charge:visible').each(function(){
       var date = normalizeDate($(this).find('.time').text());

--- a/extrato-nubank.js
+++ b/extrato-nubank.js
@@ -101,7 +101,7 @@ NEWFILEUID:NONE
   }
 
   function generateOfx() {
-    var ofx = startOfx(normalizeDate($.find('.period>span')[0].text()), normalizeDate($.find('.period>span')[1].text()));
+    var ofx = startOfx(normalizeDate($($.find('.period>span')[0]).text()), normalizeDate($($.find('.period>span')[1]).text()));
 
     $('.charge:visible').each(function(){
       var date = normalizeDate($(this).find('.time').text());

--- a/extrato-nubank.js
+++ b/extrato-nubank.js
@@ -20,7 +20,6 @@ NEWFILEUID:NONE
               <CODE>0
               <SEVERITY>INFO
           </STATUS>
-          <DTSERVER>20160711
           <LANGUAGE>ENG
           <FI>
               <ORG>NUBANK

--- a/extrato-nubank.js
+++ b/extrato-nubank.js
@@ -1,7 +1,7 @@
 
 $(function() {
 
-  function startOfx() {
+  function startOfx(from, to) {
     return `
 OFXHEADER:100
 DATA:OFXSGML
@@ -35,7 +35,9 @@ NEWFILEUID:NONE
             <ACCTID>0</ACCTID>
             <ACCTTYPE>LINEOFCREDIT</ACCTTYPE>
         </BANKACCTFROM>
-        <BANKTRANLIST>`;
+        <BANKTRANLIST>
+          <DTSTART>${from}</DTSTART>
+          <DTEND>${to}</DTEND>`;
           }
         
           function endOfx() {
@@ -99,7 +101,7 @@ NEWFILEUID:NONE
   }
 
   function generateOfx() {
-    var ofx = startOfx();
+    var ofx = startOfx(normalizeDate($(this).find('.period>span')[0].text()), normalizeDate($(this).find('.period>span')[1].text()));
 
     $('.charge:visible').each(function(){
       var date = normalizeDate($(this).find('.time').text());


### PR DESCRIPTION
I've made some changes on the mapping of OFX file to be able to import transactions on application Money Pro for Mac OS X.

Another change regarding to the amount, where spends should be a negative value.
